### PR TITLE
[benchmarks] add colab

### DIFF
--- a/assets/colabs/zenguard-benchmarks.ipynb
+++ b/assets/colabs/zenguard-benchmarks.ipynb
@@ -1,0 +1,244 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "cf926ce7",
+      "metadata": {},
+      "source": [
+        "# ZenGuard AI Prompt Attacks Benchmark\n",
+        "\n",
+        "A bit short guide on how to use ZenGuard AI Prompt Attacks Benchmark."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "8orc0SdsRdK2",
+      "metadata": {
+        "id": "8orc0SdsRdK2"
+      },
+      "source": [
+        "## Installation\n",
+        "\n",
+        "Using pip:\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "TBq9mov5vwg49M8mbcN70NeA",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "collapsed": true,
+        "executionInfo": {
+          "elapsed": 25266,
+          "status": "ok",
+          "timestamp": 1727813923527,
+          "user": {
+            "displayName": "",
+            "userId": ""
+          },
+          "user_tz": 420
+        },
+        "id": "TBq9mov5vwg49M8mbcN70NeA",
+        "outputId": "47fe7d44-8997-4d36-d9a6-babdc6b978da",
+        "tags": []
+      },
+      "outputs": [],
+      "source": [
+        "!pip install zenguard-benchmarks -U"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "jYeTxOerVknJ",
+      "metadata": {
+        "id": "jYeTxOerVknJ"
+      },
+      "source": [
+        "   ## Prerequisites\n",
+        "  \n",
+        "  Configure an API key:\n",
+        "  1. Navigate to the [Settings](https://console.zenguard.ai/settings)\n",
+        "  2. Click on the **+ Create new secret key**.\n",
+        "  3. Name the key **Quickstart Key**.\n",
+        "  4. Click on the **Add** button.\n",
+        "  5. Copy the key value by pressing the copy icon."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "-TkHxFZqV7Rx",
+      "metadata": {
+        "id": "-TkHxFZqV7Rx"
+      },
+      "source": [
+        "## Code Usage\n",
+        "\n",
+        "Instantiate the ZenGuard AI client with the API Key.\n",
+        "\n",
+        "Paste your API key into the env variable **ZEN_API_KEY**:\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "-NobuRcRV1Rh",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "executionInfo": {
+          "elapsed": 215,
+          "status": "ok",
+          "timestamp": 1727807850600,
+          "user": {
+            "displayName": "",
+            "userId": ""
+          },
+          "user_tz": 420
+        },
+        "id": "-NobuRcRV1Rh",
+        "outputId": "8f2f5077-be84-4aca-a631-8a59350552a6"
+      },
+      "outputs": [],
+      "source": [
+        "%set_env ZEN_API_KEY=<your_api_key>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "RkYt6IVKg0BV",
+      "metadata": {
+        "id": "RkYt6IVKg0BV"
+      },
+      "source": [
+        "## Code Usage explanation\n",
+        "\n",
+        "1. Instatiate the client with your api_key:\n",
+        "\n",
+        "\n",
+        "```python\n",
+        "client = ZenPromptAttacksBenchmark(api_key)\n",
+        "```\n",
+        "\n",
+        "2. Instantiate the dataset\n",
+        "\n",
+        "```python\n",
+        "client.init_dataset(\"JasperLS/prompt-injections\", \"text\", \"label\")\n",
+        "```\n",
+        "where:\n",
+        "* `dataset_name (str)`: The name of the `HuggingFace` dataset to load. This dataset will be fetched from Hugging Face datasets.\n",
+        "* `prompt_column (str)`: The name of the column that contains prompts in the dataset.\n",
+        "* `label_column (Optional)`: The name of the column that contains labels indicating whether the prompt is a prompt injection attack. If None, prompts will be assumed to be attacks by default.\n",
+        "  * Labels format supported:\n",
+        "    * `bool`: `True` - prompt contains attack, `False` - prompt does not contain attack.\n",
+        "    * `int`: `1` - prompt contains attack, `0` - prompt does not contain attack"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "hy6V2Z3SXek-",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "hy6V2Z3SXek-",
+        "outputId": "3fec5444-f578-4596-f126-032bba80d325"
+      },
+      "outputs": [],
+      "source": [
+        "from zenguard_benchmarks import ZenPromptAttacksBenchmark\n",
+        "import os\n",
+        "\n",
+        "api_key = os.getenv(\"ZEN_API_KEY\")\n",
+        "\n",
+        "client = ZenPromptAttacksBenchmark(api_key)\n",
+        "client.init_dataset(\"JasperLS/prompt-injections\", \"text\", \"label\")\n",
+        "results = client.benchmark()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "wvBOyrYDpuvZ",
+      "metadata": {
+        "id": "wvBOyrYDpuvZ"
+      },
+      "source": [
+        "## Explanation of the results\n",
+        "\n",
+        "* `Total Samples`: The total number of prompts processed.\n",
+        "* `Correct`: The number of prompts that were classified correctly.\n",
+        "* `False Positives`: The number of prompts incorrectly identified as attacks.\n",
+        "* `False Negatives`: The number of actual prompt attacks that went undetected.\n",
+        "* `Accuracy`: The ratio of correctly classified prompts to the total number of samples."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "BHTnQ-JQoxbk",
+      "metadata": {
+        "id": "BHTnQ-JQoxbk"
+      },
+      "source": [
+        "## Visualize\n",
+        "\n",
+        "Visualize the results by running:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "q2_WV6CSo51l",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 176
+        },
+        "executionInfo": {
+          "elapsed": 226,
+          "status": "error",
+          "timestamp": 1727813786517,
+          "user": {
+            "displayName": "",
+            "userId": ""
+          },
+          "user_tz": 420
+        },
+        "id": "q2_WV6CSo51l",
+        "outputId": "7c1650ad-3f75-4950-ebc9-f8bf2a20d8bf"
+      },
+      "outputs": [],
+      "source": [
+        "client.plot()"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "name": "baur (Oct 1, 2024, 10:59:28 AM)",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.12.0"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
This pull request adds a new Jupyter notebook for benchmarking ZenGuard AI prompt attacks. The notebook includes sections for installation, prerequisites, code usage, and result visualization.

New Jupyter notebook for ZenGuard AI prompt attacks benchmark:

* Added a markdown cell with an overview of the ZenGuard AI Prompt Attacks Benchmark. (`assets/colabs/zenguard-benchmarks.ipynb`)
* Included installation instructions using pip. (`assets/colabs/zenguard-benchmarks.ipynb`)
* Provided a step-by-step guide for configuring the API key. (`assets/colabs/zenguard-benchmarks.ipynb`)
* Detailed code usage for initializing the ZenGuard AI client and dataset. (`assets/colabs/zenguard-benchmarks.ipynb`)
* Added explanations for interpreting the benchmark results and visualizing them. (`assets/colabs/zenguard-benchmarks.ipynb`)