### PR TITLE
[benchmarks] make sure to run over both train and test splits

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zenguard-benchmarks"
-version = "0.0.8"
+version = "0.0.9"
 description = "Test ZenGuard AI against different datasets and benchmarks."
 authors = ["Baur Krykpayev <baur@zenguard.ai>"]
 license = "MIT"


### PR DESCRIPTION
This pull request includes several important changes to the `zenguard_benchmarks` project, focusing on version updates and improvements to dataset handling and benchmarking logic.

Version update:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3): Updated the project version from `0.0.8` to `0.0.9`.

Dataset handling improvements:

* [`zenguard_benchmarks/zenguard_prompt_attacks_benchmark.py`](diffhunk://#diff-eca46574c773465028972c0a120a7e2dc9f60365d236b8b2e74bcc2a6a4b0c0eL27-R29): Modified the `init_dataset` method to ensure the dataset contains at least one 'train' split and raise an error if it does not.

Benchmarking logic enhancements:

* [`zenguard_benchmarks/zenguard_prompt_attacks_benchmark.py`](diffhunk://#diff-eca46574c773465028972c0a120a7e2dc9f60365d236b8b2e74bcc2a6a4b0c0eL67-R75): Updated the `benchmark` method to iterate over both 'train' and 'test' splits if they exist, providing progress updates for each split during benchmarking.