### PR TITLE
[bug] fix the total samples

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zenguard-benchmarks"
-version = "0.0.9"
+version = "0.0.10"
 description = "Test ZenGuard AI against different datasets and benchmarks."
 authors = ["Baur Krykpayev <baur@zenguard.ai>"]
 license = "MIT"

--- a/zenguard_benchmarks/zenguard_prompt_attacks_benchmark.py
+++ b/zenguard_benchmarks/zenguard_prompt_attacks_benchmark.py
@@ -61,7 +61,7 @@ class ZenPromptAttacksBenchmark:
         return label.lower() == "true"
 
     def benchmark(self) -> dict:
-        total_samples = len(self._dataset)
+        total_samples = len(self._dataset["train"]) + len(self._dataset["test"])
         correct = 0
         false_positive = 0  # ZenGuard detected a prompt attack, but the label was not a prompt attack
         false_negative = 0  # ZenGuard did not detect a prompt attack, but the label was a prompt attack


### PR DESCRIPTION
This pull request includes a version bump and a fix to the benchmark calculation method in the `zenguard-benchmarks` project. The most important changes include updating the project version in `pyproject.toml` and correcting the calculation of total samples in the benchmark method.

Version update:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3): Updated the project version from `0.0.9` to `0.0.10`.

Benchmark calculation fix:

* [`zenguard_benchmarks/zenguard_prompt_attacks_benchmark.py`](diffhunk://#diff-eca46574c773465028972c0a120a7e2dc9f60365d236b8b2e74bcc2a6a4b0c0eL64-R64): Fixed the calculation of `total_samples` to include both "train" and "test" datasets.