### PR TITLE
[benchmarks] update with test split being optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zenguard-benchmarks"
-version = "0.0.10"
+version = "0.1.0"
 description = "Test ZenGuard AI against different datasets and benchmarks."
 authors = ["Baur Krykpayev <baur@zenguard.ai>"]
 license = "MIT"

--- a/zenguard_benchmarks/zenguard_prompt_attacks_benchmark.py
+++ b/zenguard_benchmarks/zenguard_prompt_attacks_benchmark.py
@@ -61,7 +61,12 @@ class ZenPromptAttacksBenchmark:
         return label.lower() == "true"
 
     def benchmark(self) -> dict:
-        total_samples = len(self._dataset["train"]) + len(self._dataset["test"])
+        total_samples = len(self._dataset["train"])
+
+        # test split is optional
+        if "test" in self._dataset:
+            total_samples += len(self._dataset["test"])
+
         correct = 0
         false_positive = 0  # ZenGuard detected a prompt attack, but the label was not a prompt attack
         false_negative = 0  # ZenGuard did not detect a prompt attack, but the label was a prompt attack


### PR DESCRIPTION
This pull request includes version updates and improvements to the benchmark calculation logic in the ZenGuard benchmarks project. The most important changes are as follows:

Version Update:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3): Updated the project version from `0.0.10` to `0.1.0`.

Benchmark Calculation Logic:
* [`zenguard_benchmarks/zenguard_prompt_attacks_benchmark.py`](diffhunk://#diff-eca46574c773465028972c0a120a7e2dc9f60365d236b8b2e74bcc2a6a4b0c0eL64-R69): Modified the `benchmark` method to handle cases where the test split is optional, ensuring that the total sample count is correctly calculated even if the test split is not present.