### PR TITLE
[docs] update docs, prints and benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ We are constantly monitoring Hugging Face for new datasets that relate to GenAI 
 
 | # | Dataset | Accuracy | Date Added |
 |---|---------|----------|------------|
-| 1 | [deepset/prompt-injections](https://huggingface.co/datasets/deepset/prompt-injections) | 87% | 2024-05-15 |
-| 2 | [JasperLS/prompt-injections](https://huggingface.co/datasets/JasperLS/prompt-injections) | 87% | 2024-05-15 |
-| 3 | [aporia-ai/prompt_injection](https://huggingface.co/datasets/aporia-ai/prompt_injection) | 87.68% | 2024-05-15 |
+
+| 1 | [xTRam1/safe-guard-prompt-injection](https://huggingface.co/datasets/xTRam1/safe-guard-prompt-injection) | 96% | 2024-07-01 |
+| 2 | [deepset/prompt-injections](https://huggingface.co/datasets/deepset/prompt-injections) | 87% | 2024-05-15 |
+| 3 | [JasperLS/prompt-injections](https://huggingface.co/datasets/JasperLS/prompt-injections) | 87% | 2024-05-15 |
+| 4 | [aporia-ai/prompt_injection](https://huggingface.co/datasets/aporia-ai/prompt_injection) | 87.68% | 2024-05-15 |
 
 ### Check for yourself. Or run your own dataset.
 

--- a/assets/colabs/zenguard-benchmarks.ipynb
+++ b/assets/colabs/zenguard-benchmarks.ipynb
@@ -3,11 +3,11 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "view-in-github"
       },
       "source": [
-          "<a target=\"_blank\" href=\"https://colab.research.google.com/github/ZenGuard-AI/zenguard-benchmarks/blob/main/assets/colabs/zenguard-benchmarks.ipynb\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a target=\"_blank\" href=\"https://colab.research.google.com/github/ZenGuard-AI/zenguard-benchmarks/blob/main/assets/colabs/zenguard-benchmarks.ipynb\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {
@@ -136,7 +136,7 @@
         "2. Instantiate the dataset\n",
         "\n",
         "```python\n",
-        "client.init_dataset(\"JasperLS/prompt-injections\", \"text\", \"label\")\n",
+        "client.init_dataset(\"deepset/prompt-injections\", \"text\", \"label\")\n",
         "```\n",
         "where:\n",
         "* `dataset_name (str)`: The name of the `HuggingFace` dataset to load. This dataset will be fetched from Hugging Face datasets.\n",
@@ -166,7 +166,7 @@
         "api_key = os.getenv(\"ZEN_API_KEY\")\n",
         "\n",
         "client = ZenPromptAttacksBenchmark(api_key)\n",
-        "client.init_dataset(\"JasperLS/prompt-injections\", \"text\", \"label\")\n",
+        "client.init_dataset(\"deepset/prompt-injections\", \"text\", \"label\")\n",
         "results = client.benchmark()"
       ]
     },

--- a/zenguard_benchmarks/zenguard_prompt_attacks_benchmark.py
+++ b/zenguard_benchmarks/zenguard_prompt_attacks_benchmark.py
@@ -92,6 +92,7 @@ class ZenPromptAttacksBenchmark:
                         false_negative += 1
                     time.sleep(CONFIG_TIME_BETWEEN_REQUESTS)
 
+        print("\n========== RUN RESULTS START ==========\n")
         print("Dataset:", self._dataset_name)
         print("ZenGuard Benchmark Results:")
         print(f"Total Samples: {total_samples}")
@@ -99,7 +100,7 @@ class ZenPromptAttacksBenchmark:
         print(f"    False Positives: {false_positive}")
         print(f"    False Negatives: {false_negative}")
         print(f"    Accuracy: {correct / total_samples:.2%}")
-        print("========== RUN FINISHED ==========\n")
+        print("\n========== RUN RESULTS END ==========\n")
 
         self._results = {
             "total_samples": total_samples,


### PR DESCRIPTION
This pull request includes updates to dataset references, improvements to the benchmark notebook, and enhanced logging for benchmark results. The most important changes are as follows:

### Dataset Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L24-R28): Updated the dataset list to include a new dataset `xTRam1/safe-guard-prompt-injection` and adjusted the order of existing datasets.

### Benchmark Notebook Improvements:
* [`assets/colabs/zenguard-benchmarks.ipynb`](diffhunk://#diff-e1a8a213edf21bd2f3c7fc65c4b517531e234e911891acc8c080af39477f432eL139-R139): Modified the dataset initialization to use `deepset/prompt-injections` instead of `JasperLS/prompt-injections` in two places. [[1]](diffhunk://#diff-e1a8a213edf21bd2f3c7fc65c4b517531e234e911891acc8c080af39477f432eL139-R139) [[2]](diffhunk://#diff-e1a8a213edf21bd2f3c7fc65c4b517531e234e911891acc8c080af39477f432eL169-R169)
* [`assets/colabs/zenguard-benchmarks.ipynb`](diffhunk://#diff-e1a8a213edf21bd2f3c7fc65c4b517531e234e911891acc8c080af39477f432eL6-R7): Adjusted the metadata of a markdown cell to correct the order of attributes.

### Enhanced Logging:
* [`zenguard_benchmarks/zenguard_prompt_attacks_benchmark.py`](diffhunk://#diff-eca46574c773465028972c0a120a7e2dc9f60365d236b8b2e74bcc2a6a4b0c0eR95-R103): Added clearer start and end markers for the benchmark run results in the logging output.